### PR TITLE
Fix Files upload API

### DIFF
--- a/lib/ruby/openai/client.rb
+++ b/lib/ruby/openai/client.rb
@@ -50,7 +50,7 @@ module OpenAI
       HTTParty.post(
         uri(path: path),
         headers: headers,
-        body: parameters
+        body: path == '/files' ? parameters : parameters.to_json
       )
     end
 

--- a/lib/ruby/openai/client.rb
+++ b/lib/ruby/openai/client.rb
@@ -67,7 +67,7 @@ module OpenAI
 
     private_class_method def self.headers
       {
-        # "Content-Type" => "application/json",
+        "Content-Type" => "application/json",
         "Authorization" => "Bearer #{Ruby::OpenAI.configuration.access_token}",
         "OpenAI-Organization" => Ruby::OpenAI.configuration.organization_id
       }


### PR DESCRIPTION

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

Hi,

The Files#upload API expects a form-data body instead of a JSON one. by adding this simple check this makes it work for all APIs.
I've looked at the [file upload VCR cassette](https://github.com/alexrudall/ruby-openai/blob/main/spec/fixtures/cassettes/files_upload.yml) to make sure it wasn't JSON, and it was using form-data as well.
